### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/md2html.go
+++ b/md2html.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"io"
 	"io/ioutil"
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 	"html/template"
 	"log"
 )


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
